### PR TITLE
Clean up variable names. Track simulation run time

### DIFF
--- a/Engine/include/engine.h
+++ b/Engine/include/engine.h
@@ -21,12 +21,12 @@ public:
 
 private:
     Environment environment_;
-    const double fixedUpdateInterval = 0.05; // how often FixedUpdate is called
+    const double kFixedUpdateInterval = 0.05; // how often FixedUpdate is called
     Simulation* simulation_;
     bool running_ = false;
 
     typedef std::chrono::system_clock timer;
-    timer::time_point engineStartTime_;
-    timer::time_point lastUpdateTime_;
-    timer::time_point lastFixedUpdateTime_;
+    timer::time_point engine_start_time_;
+    timer::time_point last_update_time_;
+    timer::time_point last_fixed_update_time_;
 };

--- a/Engine/include/simulationdata.h
+++ b/Engine/include/simulationdata.h
@@ -36,4 +36,5 @@ public:
     std::unordered_map<int, std::unordered_map<int, std::vector<int>>> creature_grid_;
     std::unordered_map<int, std::unordered_map<int, std::vector<int>>> food_grid_;
 
+    double world_time_ = 0;
 };

--- a/Engine/src/engine.cpp
+++ b/Engine/src/engine.cpp
@@ -24,9 +24,9 @@ void Engine::Run()
     if(!running_) {
         running_ = true;
 
-        engineStartTime_ = timer::now();
-        lastUpdateTime_ = engineStartTime_;
-        lastFixedUpdateTime_ = engineStartTime_;
+        engine_start_time_ = timer::now();
+        last_update_time_ = engine_start_time_;
+        last_fixed_update_time_ = engine_start_time_;
 
         simulation_->Start();
 
@@ -35,26 +35,26 @@ void Engine::Run()
 
             // time since last FixedUpdate call
             double fixed_update_delta =
-                std::chrono::duration<double>(current_time - lastFixedUpdateTime_).count();
+                std::chrono::duration<double>(current_time - last_fixed_update_time_).count();
 
             // time since last Update call
             double update_delta =
-                std::chrono::duration<double>(current_time - lastUpdateTime_).count();
+                std::chrono::duration<double>(current_time - last_update_time_).count();
 
             // we calculate how many times we should call FixedUpdate using the time since last execution
-            int fixed_update_steps = std::floor(fixed_update_delta / fixedUpdateInterval);
+            int fixed_update_steps = std::floor(fixed_update_delta / kFixedUpdateInterval);
             for (int i = 0; i < fixed_update_steps; i++) {
-                simulation_->FixedUpdate(fixedUpdateInterval);
+                simulation_->FixedUpdate(kFixedUpdateInterval);
             }
 
             simulation_->Update(update_delta);
 
-            lastUpdateTime_ = current_time;
+            last_update_time_ = current_time;
             // we increment lastFixedUpdateTime_ by the (update interval) * (number of times we called it during this cycle)
-            lastFixedUpdateTime_ +=
-                std::chrono::duration_cast<timer::time_point::duration>(
-                    std::chrono::duration<double>(fixed_update_steps * fixedUpdateInterval)
-                );
+            auto duration_to_add = std::chrono::duration_cast<timer::time_point::duration>(
+                std::chrono::duration<double>(fixed_update_steps * kFixedUpdateInterval)
+            );
+            last_fixed_update_time_ += duration_to_add;
         }
     }
 }

--- a/Engine/src/simulation.cpp
+++ b/Engine/src/simulation.cpp
@@ -13,7 +13,7 @@ Simulation::~Simulation()
 
 // Called once at the start of the simulation
 void Simulation::Start() {
-
+    std::lock_guard<std::mutex> lock(data_mutex_);
 }
 
 // Called every update cycle
@@ -33,6 +33,8 @@ void Simulation::FixedUpdate(double deltaTime)
     data_->ModifyAllCreatures(100 * deltaTime, 100 * deltaTime);
     data_->CheckFoodCollisions();
     data_->UpdateGrid();
+
+    data_->world_time_ += deltaTime;
 }
 
 // Facilitates data processing with external functions in a thread-safe manner


### PR DESCRIPTION
- Cleaned up variable names in the engine class
- Added a field to SimulationData that keeps track of the total time since the beginning (with respect to the physics simulation speed)