### PR TITLE
Separate Health and Energy

### DIFF
--- a/Engine/include/creature.h
+++ b/Engine/include/creature.h
@@ -11,15 +11,22 @@ public:
 
     void Dies();
     void Eats(double nutritional_value);
-    void UpdateEnergy();
+    void UpdateEnergy(const double energyToHealth, const double healthToEnergy);
     double GetEnergy() const;
     void SetEnergy(double energy);
+
+    double GetHealth() const;
+    void SetHealth(double health);
+
+    void HealthToEnergy();
+    void EnergyToHealth();
 
     virtual void OnCollision(Food& food);
     virtual void OnCollision(Creature& creature);
 
 private:
     double energy_;
+    double health_;
 };
 
 #endif // CREATURE_HPP

--- a/Engine/include/environment.h
+++ b/Engine/include/environment.h
@@ -22,6 +22,10 @@ public:
     // Tolerance of collisions
     static constexpr double kTolerance = 1e-3;
 
+    // Energy and Health conversion thresholds
+    static constexpr double energyToHealth = 70.0;
+    static constexpr double healthToEnergy = 10.0;
+
     // Constructor
     Environment();
 

--- a/Engine/src/creature.cpp
+++ b/Engine/src/creature.cpp
@@ -1,8 +1,9 @@
 #include "creature.h"
 
 Creature::Creature()
-    : MovableEntity(), energy_(0.0) {
-
+    : MovableEntity() {
+    health_ = 100;
+    energy_ = 100;
 }
 
 double Creature::GetEnergy() const {
@@ -10,14 +11,50 @@ double Creature::GetEnergy() const {
 }
 
 void Creature::SetEnergy(double energy) {
-    energy_ = energy;
+    if (energy > 100) {
+        energy_ = 100;
+    } else {
+        energy_ = energy;
+    }
 }
 
-void Creature::UpdateEnergy(){
+void Creature::UpdateEnergy(const double energyToHealth, const double healthToEnergy){
     SetEnergy( GetEnergy() - (GetVelocityForward() + GetRotationalVelocity()) * GetSize());
 
-    if (GetEnergy() <= 0){
+    if (GetEnergy() <= healthToEnergy){
+        HealthToEnergy();
+    } else if (GetEnergy() >= energyToHealth){
+        EnergyToHealth();
+    }
+
+    if (GetHealth() <= 0){
         Dies();
+    }
+}
+
+void Creature::HealthToEnergy() {
+    if (GetEnergy() < 0) {
+        SetHealth(GetHealth()- GetEnergy()-5);
+        SetEnergy(5);
+    }
+    SetEnergy(GetEnergy() + 5);
+    SetHealth(GetHealth() - 5);
+}
+
+void Creature::EnergyToHealth() {
+    SetEnergy(GetEnergy() - 5);
+    SetHealth(GetHealth() + 5);
+}
+
+double Creature::GetHealth() const {
+    return health_;
+}
+
+void Creature::SetHealth(double health) {
+    if (health > 100) {
+        health_ = 100;
+    } else {
+        health_ = health;
     }
 }
 
@@ -27,7 +64,9 @@ void Creature::Dies(){
 
 void Creature::Eats(double nutritional_value){
     SetEnergy(GetEnergy() + nutritional_value);
-}
+    if (GetEnergy() > 100) {
+        EnergyToHealth();
+    }}
 
 void Creature::OnCollision(Food& food)
 {


### PR DESCRIPTION
Added health_ to creature class (with Get and Set health functions)

Modified Creature initialisation so health_ and energy_ are initially set to 100.

Modified SetEnergy and SetHealth so that the maximum value is 100.

Added HealthToEnergy and EnergyToHealth functions to creature class: Currently, they are both changed by +/- 5. If energy is below 0, you lose health until energy = 5

Added the threshold for health and energy conversion to the environment class.

modified death condition to depend on health instead of energy (checked at the end of UpdateEnergy).

All energy and health updates start from EnergyUpdate or Eats.