### PR TITLE
Neat speciation/cycles

### DIFF
--- a/Engine/include/neat/neat-genome.h
+++ b/Engine/include/neat/neat-genome.h
@@ -55,10 +55,7 @@ class Genome {
                                    neurons in the Genome. */
   std::vector<Link> links_;     /*!< A vector of Link objects representing the
                                    connections between neurons in the Genome.
-                                   These connections do not induce cycles on their own */
- /* std::vector<Link> cycle_links_; /*!< A vector of Link objects representing the connections
-                                      that introduce cycles. They are separated from other links
-                                        because they are usually considered in different scenarios. */
+                                    */
   bool DFS(const Neuron& currentNeuron, std::unordered_set<int>& visited,
            std::unordered_set<int>& visiting) const;
 };

--- a/Engine/include/neat/neat-genome.h
+++ b/Engine/include/neat/neat-genome.h
@@ -54,7 +54,11 @@ class Genome {
   std::vector<Neuron> neurons_; /*!< A vector of Neuron objects representing the
                                    neurons in the Genome. */
   std::vector<Link> links_;     /*!< A vector of Link objects representing the
-                                   connections between neurons in the Genome. */
+                                   connections between neurons in the Genome.
+                                   These connections do not induce cycles on their own */
+ /* std::vector<Link> cycle_links_; /*!< A vector of Link objects representing the connections
+                                      that introduce cycles. They are separated from other links
+                                        because they are usually considered in different scenarios. */
   bool DFS(const Neuron& currentNeuron, std::unordered_set<int>& visited,
            std::unordered_set<int>& visiting) const;
 };

--- a/Engine/include/neat/neat-link.h
+++ b/Engine/include/neat/neat-link.h
@@ -20,10 +20,13 @@ class Link {
   int GetOutId() const;
   double GetWeight() const;
   bool IsActive() const;
+  bool IsCyclic() const;
 
   void SetWeight(double weight);
   void SetActive();
   void SetInactive();
+  void SetCyclic();
+  void SetNonCyclic();
 
  private:
   static int
@@ -33,6 +36,7 @@ class Link {
   int out_id_;  /*!< ID of the output neuron. */
   double weight_; /*!< Weight of the connection. */
   bool active_;   /*!< Indicates whether the link is active or not. */
+  bool cyclic_;  /*!< Indicates whether the link introduces a cycle or not. */
 };
 
 Link CrossoverLink(const Link &a, const Link &b);

--- a/Engine/include/neat/neat-neural-network.h
+++ b/Engine/include/neat/neat-neural-network.h
@@ -27,20 +27,20 @@ struct NeuronInput {
  * @brief Represents a neuron in a feed-forward neural network.
  *
  * @details This structure is used to represent a neuron in the neural network
- * constructed from a NEAT genome. It includes the neuron's ID, its bias, and
- * its input connections.
+ * constructed from a NEAT genome. It includes the neuron's ID, its bias, the
+ * value it stores and its input connections.
  */
 struct FeedForwardNeuron {
   int id;       /*!< The ID of the neuron. */
   double bias;  /*!< The bias of the neuron. */
   double value; /*!< The value of the neuron. Important for the neurons which
-                   are at the end of a cycle.*/
+                   start a cycle.*/
   std::vector<NeuronInput> inputs; /*!< A vector of NeuronInput representing the
                                       inputs to this neuron. */
   std::vector<NeuronInput>
       inputs_from_cycles; /*!< A vector of NeuronInput representing the
                  inputs from the previous neurons in the cycles. Note that one
-                 neuron can be at the ends of multiple cycles*/
+                 neuron can be at the starts of multiple cycles*/
 };
 
 /*!

--- a/Engine/include/neat/neat-neural-network.h
+++ b/Engine/include/neat/neat-neural-network.h
@@ -61,7 +61,6 @@ class NeuralNetwork {
   std::vector<FeedForwardNeuron> GetNeurons() const;
 
  private:
-  std::shared_ptr<const Genome> genome_;
   std::vector<int> input_ids_;  /*!< IDs of input neurons. */
   std::vector<int> output_ids_; /*!< IDs of output neurons. */
   std::vector<FeedForwardNeuron>

--- a/Engine/include/neat/neat-neural-network.h
+++ b/Engine/include/neat/neat-neural-network.h
@@ -54,7 +54,8 @@ struct FeedForwardNeuron {
 class NeuralNetwork {
  public:
   NeuralNetwork(const Genome &genom);
-  std::vector<double> Activate(const std::vector<double> &input_values) const;
+  std::vector<double> Activate(const std::vector<double> &input_values);
+  std::vector<FeedForwardNeuron> GetNeurons() const;
 
  private:
   std::vector<int> input_ids_;  /*!< IDs of input neurons. */

--- a/Engine/include/neat/neat-neural-network.h
+++ b/Engine/include/neat/neat-neural-network.h
@@ -30,12 +30,17 @@ struct NeuronInput {
  * constructed from a NEAT genome. It includes the neuron's ID, its bias, and
  * its input connections.
  */
-struct FeedForwardNeuron {  // Functional units of the NeuralNetowork, obtained
-                            // from Neurons and Links
-  int id;                   /*!< The ID of the neuron. */
-  double bias;              /*!< The bias of the neuron. */
+struct FeedForwardNeuron {
+  int id;       /*!< The ID of the neuron. */
+  double bias;  /*!< The bias of the neuron. */
+  double value; /*!< The value of the neuron. Important for the neurons which
+                   are at the end of a cycle.*/
   std::vector<NeuronInput> inputs; /*!< A vector of NeuronInput representing the
                                       inputs to this neuron. */
+  std::vector<NeuronInput>
+      inputs_from_cycles; /*!< A vector of NeuronInput representing the
+                 inputs from the previous neurons in the cycles. Note that one
+                 neuron can be at the ends of multiple cycles*/
 };
 
 /*!

--- a/Engine/src/neat/neat-genome.cpp
+++ b/Engine/src/neat/neat-genome.cpp
@@ -455,8 +455,9 @@ void Genome::MutateAddLink() {
     return;  // IF WE END UP USING ENABLED/DISABLE LINKS, THEN ENABLE LINK
   }
 
-  // Check if cycle exists:
   AddLink(Link(n1, n2, 1));
+  // Check if cycle exists:
+
   if (DetectLoops(neurons_[indexRandomNeuron1])) {
     //RemoveLink(newl.GetId());
     links_.back().SetCyclic();
@@ -468,9 +469,7 @@ void Genome::MutateAddLink() {
  * @brief Mutates the Genome by adding a new neuron.
  *
  * @details Adds a new neuron by splitting an existing link and connecting the
- * new neuron in between. It never splits a cyclic link, it chooses a random
- * link until it gets a non-cyclic one. Since most links are non-cyclic, this is
- * ok.
+ * new neuron in between.
  */
 void Genome::MutateAddNeuron() {
   if (links_.size() == 0) {
@@ -481,18 +480,19 @@ void Genome::MutateAddNeuron() {
   std::uniform_int_distribution<size_t> dist(0, links_.size() - 1);
   size_t randIndex = dist(gen);
   Link RandomLink = links_[randIndex];
-  while (RandomLink.IsCyclic()) {
-    std::mt19937 gen(rd());
-    randIndex = dist(gen);
-    RandomLink = links_[randIndex];
-  }
+
   DisableLink(RandomLink.GetId());  // test
 
   AddNeuron(Neuron(NeuronType::kHidden, 0.0));
   // disable the initial link between the inId and outId
   int newNeuronId = neurons_.back().GetId();
-  AddLink(Link(RandomLink.GetInId(), newNeuronId, 1));
-  AddLink(Link(newNeuronId, RandomLink.GetOutId(), RandomLink.GetWeight()));
+  Link newlink1(RandomLink.GetInId(), newNeuronId, 1);
+  Link newlink2(newNeuronId, RandomLink.GetOutId(), RandomLink.GetWeight());
+  if (RandomLink.IsCyclic()) {
+    newlink2.SetCyclic();
+  }
+  AddLink(newlink1);
+  AddLink(newlink2);
 }
 
 /*!

--- a/Engine/src/neat/neat-genome.cpp
+++ b/Engine/src/neat/neat-genome.cpp
@@ -206,14 +206,14 @@ void Genome::Mutate() {
   if (uniform(gen) < settings::neat::kAddLinkMutationRate) {
     MutateAddLink();
   }
+  /* cycles aren't supported with remove mutations
+    if (uniform(gen) < settings::neat::kRemoveNeuronMutationRate) {
+      MutateRemoveNeuron();
+    }/*
 
-  if (uniform(gen) < settings::neat::kRemoveNeuronMutationRate) {
-    MutateRemoveNeuron();
-  }
-
-  if (uniform(gen) < settings::neat::kRemoveLinkMutationRate) {
-    MutateRemoveLink();
-  }
+  /*  if (uniform(gen) < settings::neat::kRemoveLinkMutationRate) {
+      MutateRemoveLink();
+    }*/
 
   if (uniform(gen) < settings::neat::kChangeWeightMutationRate) {
     MutateChangeWeight();

--- a/Engine/src/neat/neat-link.cpp
+++ b/Engine/src/neat/neat-link.cpp
@@ -25,7 +25,8 @@ Link::Link(int in_id, int out_id, double weight)
       in_id_(in_id),
       out_id_(out_id),
       weight_(weight),
-      active_(true) {}
+      active_(true),
+      cyclic_(false) {}
 
 /*!
  * @brief Gets the unique identifier of the link.
@@ -64,10 +65,18 @@ double Link::GetWeight() const { return weight_; }
 bool Link::IsActive() const { return active_; }
 
 /*!
+ * @brief Checks if the link is cyclic.
+ *
+ * @return True if the link is cyclic, false otherwise.
+ */
+bool Link::IsCyclic() const { return cyclic_; }
+
+/*!
  * @brief Sets the weight of the link.
  *
  * @param weight The new weight to be set for the connection.
  */
+
 void Link::SetWeight(double weight) { weight_ = weight; }
 
 /*!
@@ -79,6 +88,17 @@ void Link::SetActive() { active_ = true; }
  * @brief Sets the link to be inactive.
  */
 void Link::SetInactive() { active_ = false; }
+
+/*!
+ * @brief Sets the link to be cyclic.
+ */
+void Link::SetCyclic() { cyclic_ = true; }
+
+/*!
+ * @brief Sets the link to be non-cyclic.
+ */
+void Link::SetNonCyclic() { cyclic_ = false; }
+
 
 /*!
  * @brief Creates a new Link with specified input and output neuron IDs and

--- a/Engine/src/neat/neat-neural-network.cpp
+++ b/Engine/src/neat/neat-neural-network.cpp
@@ -14,24 +14,23 @@
 namespace neat {
 
 /*!
- * @brief Constructs a NeuralNetwork from a given Genome.
+ * @brief  Constructs a NeuralNetwork object
+ from a genome object, assuming the genome
+ represents a valid neural network (ie the cyclic
+ links are labeled as such etc.)
  *
  * @param genome The Genome to construct the NeuralNetwork from.
  */
 NeuralNetwork::NeuralNetwork(const Genome &genom) {
   std::vector<std::vector<Neuron> > layers = get_layers(genom);
-  // std::vector<Neuron> neurons = genom.GetNeurons();
   std::vector<FeedForwardNeuron> ffneurons;
-  // std::vector<int> input_ids;
+
   for (const Neuron &neuron : layers.front()) {
     input_ids_.push_back(neuron.GetId());
   }
-  // input_ids_ = input_ids;
-  // std::vector<int> output_ids;
   for (const Neuron &neuron : layers.back()) {
     output_ids_.push_back(neuron.GetId());
   }
-  // output_ids_ = output_ids;
 
   for (const std::vector<Neuron> &layer : layers) {
     for (const Neuron &neuron : layer) {
@@ -55,15 +54,24 @@ NeuralNetwork::NeuralNetwork(const Genome &genom) {
   ffneurons_ = ffneurons;
 }
 
+std::vector<FeedForwardNeuron> NeuralNetwork::GetNeurons() const {
+  return ffneurons_;
+}
+
 /*!
- * @brief Activates the neural network with a given set of input values.
+ * @brief Produces an output of the
+                                neural network based on the values of input
+                             neurons (input_values vector) and the values of
+                             neurons involved in cycles (stored inside each
+                             ffneuron). Also updates the values of neurons
+                             involved in cycles.
  *
  * @param input_values The input values to feed into the network.
  *
  * @return A vector of output values after network activation.
  */
 std::vector<double> NeuralNetwork::Activate(
-    const std::vector<double> &input_values) const {
+    const std::vector<double> &input_values) {
   assert(input_values.size() == input_ids_.size());
   std::unordered_map<int, double> values;
   for (int i = 0; i < input_values.size(); i++) {
@@ -93,7 +101,7 @@ std::vector<double> NeuralNetwork::Activate(
   }
 
   // update values of ffneurons which are at the end of a cycle
-  for (const FeedForwardNeuron &ffneuron : ffneurons_) {
+  for (FeedForwardNeuron &ffneuron : ffneurons_) {
     ffneuron.value = 0;
     for (const NeuronInput &neuron_input : ffneuron.inputs_from_cycles) {
       ffneuron.value += neuron_input.weight * values[neuron_input.input_id];
@@ -133,7 +141,6 @@ std::vector<std::vector<Neuron> > get_layers(const Genome &genom) {
     }
   }
   layers.push_back(input_layer);
-
   for (const Neuron &neuron : neurons) {
     if (neuron.GetType() == NeuronType::kOutput) {
       output_layer.push_back(neuron);

--- a/Engine/src/neat/neat-neural-network.cpp
+++ b/Engine/src/neat/neat-neural-network.cpp
@@ -105,9 +105,10 @@ std::vector<double> NeuralNetwork::Activate(
     }
   }
 
-  // update values of ffneurons. this affects those neurons which start a cycle
+  // update values stored by ffneurons. this affects those neurons which start a
+  // cycle
   for (FeedForwardNeuron &ffneuron : ffneurons_) {
-    ffneuron.value = 0;
+    // ffneuron.value = 0;
     for (const NeuronInput &neuron_input : ffneuron.inputs_from_cycles) {
       ffneuron.value += neuron_input.weight * values[neuron_input.input_id];
     }
@@ -186,7 +187,8 @@ std::vector<std::vector<Neuron> > get_layers(const Genome &genom) {
 /*!
  * @brief Activation function used in the neural network.
  *
- * @param n the neuron to be activated, x The input value to the activation function.
+ * @param n indicates which function to apply, x The input value to the
+ * activation function.
  *
  * @return The output of the activation function.
  */

--- a/Engine/src/neat/neat-neural-network.cpp
+++ b/Engine/src/neat/neat-neural-network.cpp
@@ -100,7 +100,7 @@ std::vector<double> NeuralNetwork::Activate(
     }
   }
 
-  // update values of ffneurons which are at the end of a cycle
+  // update values of ffneurons. this affects those neurons which start a cycle
   for (FeedForwardNeuron &ffneuron : ffneurons_) {
     ffneuron.value = 0;
     for (const NeuronInput &neuron_input : ffneuron.inputs_from_cycles) {

--- a/Engine/tests/collisions.cpp
+++ b/Engine/tests/collisions.cpp
@@ -521,6 +521,8 @@ TEST_F(CreatureTest, GetClosestFoodTest2) {
  * @details Ensures that the grid is initialized with the expected number of
  * cells based on the simulation settings.
  */
+
+/*
 TEST(SimulationDataTest, GridInitialization) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -541,7 +543,7 @@ TEST(SimulationDataTest, GridInitialization) {
   for (const auto& row : simData.GetGrid()) {
     EXPECT_EQ(row.size(), expectedNumCellsY);
   }
-}
+}*/
 
 /*!
  * @brief Tests for updating the grid with alive entities.
@@ -549,6 +551,7 @@ TEST(SimulationDataTest, GridInitialization) {
  * @details Validates that the grid correctly places alive entities and ignores
  * dead ones.
  */
+/*
 TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -583,7 +586,7 @@ TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
       }
     }
   }
-}
+}*/
 
 /*!
  * @brief Tests for correct placement of entities in the grid.
@@ -591,6 +594,8 @@ TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
  * @details Ensures that entities are placed in the correct grid cells even when
  *          their coordinates are outside the nominal bounds of the map.
  */
+
+/*
 TEST(SimulationDataTest, CorrectEntityPlacementInGrid) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -636,7 +641,7 @@ TEST(SimulationDataTest, CorrectEntityPlacementInGrid) {
 
   EXPECT_NE(simData.GetGrid()[creatureGridX][creatureGridY].empty(), true);
   EXPECT_NE(simData.GetGrid()[foodGridX][foodGridY].empty(), true);
-}
+}*/
 
 /*!
  * @brief Tests for calculating neighboring cells in a grid.

--- a/Engine/tests/collisions.cpp
+++ b/Engine/tests/collisions.cpp
@@ -522,7 +522,6 @@ TEST_F(CreatureTest, GetClosestFoodTest2) {
  * cells based on the simulation settings.
  */
 
-/*
 TEST(SimulationDataTest, GridInitialization) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -543,7 +542,7 @@ TEST(SimulationDataTest, GridInitialization) {
   for (const auto& row : simData.GetGrid()) {
     EXPECT_EQ(row.size(), expectedNumCellsY);
   }
-}*/
+}
 
 /*!
  * @brief Tests for updating the grid with alive entities.
@@ -551,7 +550,7 @@ TEST(SimulationDataTest, GridInitialization) {
  * @details Validates that the grid correctly places alive entities and ignores
  * dead ones.
  */
-/*
+
 TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -586,7 +585,7 @@ TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
       }
     }
   }
-}*/
+}
 
 /*!
  * @brief Tests for correct placement of entities in the grid.
@@ -595,7 +594,6 @@ TEST(SimulationDataTest, UpdateGridWithAliveEntities) {
  *          their coordinates are outside the nominal bounds of the map.
  */
 
-/*
 TEST(SimulationDataTest, CorrectEntityPlacementInGrid) {
   myEnvironment::Environment environment;
   SimulationData simData(environment);
@@ -641,7 +639,7 @@ TEST(SimulationDataTest, CorrectEntityPlacementInGrid) {
 
   EXPECT_NE(simData.GetGrid()[creatureGridX][creatureGridY].empty(), true);
   EXPECT_NE(simData.GetGrid()[foodGridX][foodGridY].empty(), true);
-}*/
+}
 
 /*!
  * @brief Tests for calculating neighboring cells in a grid.

--- a/Engine/tests/neat.cpp
+++ b/Engine/tests/neat.cpp
@@ -330,8 +330,9 @@ TEST(NeatTests, Mutate) {
   // Check that each mutation happened at least once
   EXPECT_GT(countAddNeuron, 0);
   EXPECT_GT(countAddLink, 0);
-  EXPECT_GT(countRemoveNeuron, 0);
-  EXPECT_GT(countRemoveLink, 0);
+  // EXPECT_GT(countRemoveNeuron, 0);
+  // EXPECT_GT(countRemoveLink, 0); cycles aren't compatible with these
+  // mutations
   EXPECT_GT(countChangeWeight, 0);
 }
 
@@ -485,13 +486,13 @@ TEST(NeatTests, MutateAddLink) {
  */
 TEST(NeatTests, GetLayers) {
   Genome genome(3, 2);
-  genome.AddLink(Link(0, 3, 1));
-  genome.AddLink(Link(2, 4, 1));
   genome.AddLink(Link(1, 4, 1));
-  genome.AddLink(Link(2, 3, 1));
+  genome.AddLink(Link(3, 5, 1));
+  genome.AddLink(Link(2, 5, 1));
+  genome.AddLink(Link(3, 4, 1));
   genome.AddNeuron(Neuron(NeuronType::kHidden, 0.5));
-  genome.AddLink(Link(0, 5, 1));
-  genome.AddLink(Link(5, 3, 1));
+  genome.AddLink(Link(1, 6, 1));
+  genome.AddLink(Link(6, 4, 1));
 
   const std::vector<Neuron>& neurons = genome.GetNeurons();
   std::vector<std::vector<Neuron>> true_layers = {
@@ -518,19 +519,68 @@ TEST(NeatTests, GetLayers) {
  */
 TEST(NeatTests, NeuralNetworkActivate) {
   Genome genome(3, 2);
-  genome.AddLink(Link(0, 3, 1));
-  genome.AddLink(Link(2, 4, 1));
   genome.AddLink(Link(1, 4, 1));
-  genome.AddLink(Link(2, 3, 1));
+  genome.AddLink(Link(3, 5, 1));
+  genome.AddLink(Link(2, 5, 1));
+  genome.AddLink(Link(3, 4, 1));
   genome.AddNeuron(Neuron(NeuronType::kHidden, 0.5));
-  genome.AddLink(Link(0, 5, 1));
-  genome.AddLink(Link(5, 3, 1));
+  genome.AddLink(Link(1, 6, 1));
+  genome.AddLink(Link(6, 4, 1));
   NeuralNetwork neural_network(genome);
   std::vector<double> input_values = {1, 1, 1};
   std::vector<double> output_values = neural_network.Activate(input_values);
 
   ASSERT_FALSE(
       output_values.empty());  // Replace with more specific checks as needed
+}
+
+/*!
+ * @brief Tests the activation function of the NeuralNetwork constructed from a
+ * Genome that contains cycles.
+ *
+ * @details Ensures that the NeuralNetwork activates correctly with given input
+ * values and produces (some) output values. Also checks that neurons store some
+ * information from the previous activation.
+ */
+TEST(NeatTests, NeuralNetworkActivate_with_cycles) {
+  Genome genome(3, 1);
+  genome.AddNeuron(Neuron(NeuronType::kHidden, 0.5));
+  genome.AddNeuron(Neuron(NeuronType::kHidden, 0.4));
+  genome.AddNeuron(Neuron(NeuronType::kHidden, 0.3));
+  genome.AddLink(Link(1, 5, 1));
+  genome.AddLink(Link(2, 7, 1));
+  genome.AddLink(Link(3, 7, 1));
+  genome.AddLink(Link(5, 6, 1));
+  genome.AddLink(Link(6, 7, 1));
+  Link cyclink(7, 5, 1);
+  cyclink.SetCyclic();
+  genome.AddLink(cyclink);
+  genome.AddLink(Link(6, 4, 1));
+
+  NeuralNetwork neural_network(genome);
+
+  std::vector<double> input_values = {1, 1, 1};
+  std::vector<double> output_values = neural_network.Activate(input_values);
+
+  ASSERT_FALSE(
+      output_values.empty());  // Replace with more specific checks as needed
+
+  // checking how many neurons are at the start of a cycle
+  int counter = 0;
+  for (const FeedForwardNeuron& ffneuron : neural_network.GetNeurons()) {
+    // std::cerr << ffneuron.id << " ";
+    // std::cerr << ffneuron.inputs_from_cycles.size() << " ";
+    if (ffneuron.inputs_from_cycles.size() > 0) {
+      counter++;
+    }
+  }
+  EXPECT_EQ(counter, 1);
+
+  // checking values stored in neurons
+  /*
+  for (const FeedForwardNeuron& ffneuron : neural_network.GetNeurons()) {
+    std::cerr << ffneuron.value << " ";
+  }*/
 }
 
 /*!
@@ -652,8 +702,8 @@ TEST(NeatTests, Crossover) {
               crossoverResult.GetNeurons().end());
   }
 
-  // Check that every link ID in crossoverResult also exists in genomeA and vice
-  // versa
+  // Check that every link ID in crossoverResult also exists in genomeA and
+  // vice versa
   for (const auto& link : crossoverResult.GetLinks()) {
     EXPECT_NE(std::find_if(
                   genomeA.GetLinks().begin(), genomeA.GetLinks().end(),
@@ -722,7 +772,6 @@ TEST(NeatTests, Crossover) {
  * underwent mutations and crossover activates correctly.
  */
 
-/*
 TEST(NeatTests, ActivationAfterMutateCrossover) {
   Genome genomeA(3, 1);
 
@@ -751,4 +800,4 @@ TEST(NeatTests, ActivationAfterMutateCrossover) {
   std::cerr << nn.Activate({1, 1, 1})[0] << std::endl;
   std::cerr << nn.Activate({1, 0, 1})[0] << std::endl;
   std::cerr << nn.Activate({0, 1, 1})[0] << std::endl;
-}*/
+}

--- a/Engine/tests/neat.cpp
+++ b/Engine/tests/neat.cpp
@@ -424,6 +424,60 @@ TEST(NeatTests, MutateChangeWeight) {
 }
 
 /*!
+ * @brief Tests add-neuron mutations.
+ *
+ * @details Validates that MutateAddNeuron adds neurons by splitting a link.
+ */
+TEST(NeatTests, MutateAddNeuron) {
+  Genome genome(3, 2);
+  genome.AddLink(Link(1, 4, 2.0));
+  genome.AddLink(Link(1, 5, 2.0));
+  genome.AddLink(Link(2, 4, 2.0));
+  genome.AddLink(Link(3, 5, 2.0));
+
+  for (int i = 0; i < 20; i++) {
+    genome.MutateAddNeuron();
+  }
+  EXPECT_EQ(genome.GetNeurons().size(), 25);
+
+  Genome genome2(3, 2);
+  genome2.AddLink(Link(1, 4, 2.0));
+  genome2.MutateAddNeuron();
+
+  EXPECT_FALSE(genome2.GetLinks().front().IsActive());
+  EXPECT_EQ(genome2.GetLinks().size(), 3);
+}
+
+/*!
+ * @brief Tests add-link mutations.
+ *
+ * @details Validates that MutateAddLink adds a link between neurons and sets
+ *  this link to be cyclic if needed.
+ */
+TEST(NeatTests, MutateAddLink) {
+  Genome genome(2, 2);
+
+  for (int i = 0; i < 100; i++) {
+    genome.MutateAddLink();
+  }
+  ASSERT_TRUE(genome.GetLinks().size() >=
+              1);  // at least one link should should be added
+  for (int i = 0; i < 3; i++) {
+    genome.MutateAddNeuron();
+  }
+  for (int i = 0; i < 100; i++) {
+    genome.MutateAddLink();
+  }
+  bool cycle = false;
+  for (const auto& link : genome.GetLinks()) {
+    if (link.IsCyclic()) {
+      cycle = true;
+    }
+  }
+  EXPECT_TRUE(cycle);
+}
+
+/*!
  * @brief Tests generating layers of neurons from a Genome.
  *
  * @details Validates that the get_layers function correctly organizes neurons
@@ -667,6 +721,8 @@ TEST(NeatTests, Crossover) {
  * @details Ensures that a NeuralNetwork constructed from a Genome that
  * underwent mutations and crossover activates correctly.
  */
+
+/*
 TEST(NeatTests, ActivationAfterMutateCrossover) {
   Genome genomeA(3, 1);
 
@@ -695,4 +751,4 @@ TEST(NeatTests, ActivationAfterMutateCrossover) {
   std::cerr << nn.Activate({1, 1, 1})[0] << std::endl;
   std::cerr << nn.Activate({1, 0, 1})[0] << std::endl;
   std::cerr << nn.Activate({0, 1, 1})[0] << std::endl;
-}
+}*/


### PR DESCRIPTION
Cycles are now implemented.

How cycles are introduced:

Link class now has a boolean data member called `cyclic_` which indicates if the link introduces cycles. 

When `MutateAddLink` is called, it chooses two neurons at random (that are not already linked plus some other restrictions), and checks if adding a link between them induces a cycle inside the network (using dfs). If it doesn't, a link between them is added and its cyclic_ parameter is set to false. If it does, a link is still added but with a cycle_ parameter equal to true. We will call the out neuron of a cyclic link Start neuron (it is at the beginning of a cycle), and the in neuron will be called End neuron (it is at the end of a cycle). This notation will be clarified in the next section.

How cycles work:

Activation of a neural network can be divided into two stages. The first stage is the feed-forward part, where we compute the values of output neurons based on the values of input neurons. This is done almost exactly like before, except that the cyclic links are ignored in this stage, and neurons are now storing values from a previous activation. When we forward-propagate through a network, each neuron obtains its new value by adding the bias and the weighted sum of its input neurons' values to its stored value, and then applying an activation function. 

In the second stage, the stored values are updated. Every Start neuron will store a value equal to the weighted sum of its corresponding End neurons' values (obtained in the first stage). All the other neurons store 0. Here we only consider the cyclic links.
 
