### PR TITLE
Implemented coordinate-dependent food density; added food spawn rate

### DIFF
--- a/Engine/include/config.h
+++ b/Engine/include/config.h
@@ -22,16 +22,16 @@ constexpr double kAdjustmentProbability = 0.8;
 }  // namespace neat
 
 namespace environment {
-constexpr double kMapWidth = 1900.0;
-constexpr double kMapHeight = 880.0;
-constexpr double kCreatureDensity = 0.0005;
+constexpr double kMapWidth = 1000;
+constexpr double kMapHeight = 500;
 constexpr int kMaxFoodSize = 15;
 constexpr int kMaxCreatureSize = 15;
 constexpr double kTolerance = 1e-3;
-constexpr double kDefaultFoodDensity = 0.005;
+constexpr double kDefaultFoodDensity = 5e-4;
+constexpr double kFoodSpawnRate = 1e-3;
 constexpr double kEnergyToHealth = 70.0;
 constexpr double kHealthToEnergy = 10.0;
-constexpr double kDefaultCreatureDensity = 0.0001;
+constexpr double kDefaultCreatureDensity = 5e-4;
 constexpr double kPlantNutritionalValue = 2.0;
 constexpr double kMeatNutritionalValue = 3.0;
 constexpr double kRotFactor = 1.0;

--- a/Engine/include/environment.h
+++ b/Engine/include/environment.h
@@ -2,6 +2,7 @@
 #define ENVIRONMENT_H
 #include <iostream>
 #include <vector>
+#include <functional>
 
 #include "config.h"
 
@@ -12,9 +13,10 @@ class Environment {
   Environment();
 
   // Getter and setter for food density
-  void SetFoodDensity(double density) { food_density_ = density; }
+  void SetFoodDensity(double density);
+  void SetFoodDensity(std::function<double(double, double)> density_func);
 
-  double GetFoodDensity() const { return food_density_; }
+  double GetFoodDensity(double x, double y);
 
   // Getter and setter for creature density
   void SetCreatureDensity(double density) { creature_density_ = density; }
@@ -24,7 +26,8 @@ class Environment {
   double GetFrictionalCoefficient() const { return friction_coefficient_; }
 
  private:
-  double food_density_;  // Variable for creature density
+  // lambda for food density
+  std::function <double(double, double)> food_density_func_;
   double creature_density_;
   double friction_coefficient_;
 };

--- a/Engine/include/simulationdata.h
+++ b/Engine/include/simulationdata.h
@@ -25,7 +25,7 @@ struct SimulationData {
   void AddCreature(const Creature& entity);
   void RemoveCreature(const Creature& entity);
 
-  void GenerateMoreFood();
+  void GenerateMoreFood(double deltaTime);
   void UpdateGrid();
   void ClearGrid();
 

--- a/Engine/src/engine.cpp
+++ b/Engine/src/engine.cpp
@@ -33,12 +33,12 @@ void Engine::Run() {
       // time since last FixedUpdate call
       double fixed_update_delta =
           std::chrono::duration<double>(current_time - last_fixed_update_time_)
-              .count();
+              .count() * 2;
 
       // time since last Update call
       double update_delta =
           std::chrono::duration<double>(current_time - last_update_time_)
-              .count();
+              .count() * 2;
 
       // we calculate how many times we should call FixedUpdate using the time
       // since last execution

--- a/Engine/src/environment.cpp
+++ b/Engine/src/environment.cpp
@@ -6,6 +6,22 @@
 
 // Constructor implementation
 myEnvironment::Environment::Environment()
-    : food_density_(settings::environment::kDefaultFoodDensity),
-      creature_density_(settings::environment::kDefaultCreatureDensity),
-      friction_coefficient_(settings::environment::kFrictionalCoefficient) {}
+    : food_density_func_(
+          [](double x, double y) { return settings::environment::kDefaultFoodDensity; }),
+    creature_density_(settings::environment::kDefaultCreatureDensity),
+    friction_coefficient_(settings::environment::kFrictionalCoefficient) {}
+
+void myEnvironment::Environment::SetFoodDensity(double density)
+{
+    food_density_func_ = [density](double x, double y) { return density; };
+}
+
+void myEnvironment::Environment::SetFoodDensity(std::function<double(double, double)> density)
+{
+    food_density_func_ = density;
+}
+
+double myEnvironment::Environment::GetFoodDensity(double x, double y)
+{
+    return food_density_func_(x, y);
+}

--- a/Engine/src/simulation.cpp
+++ b/Engine/src/simulation.cpp
@@ -22,7 +22,7 @@ void Simulation::FixedUpdate(double deltaTime) {
   // Test function (DO NOT USE)
   data_->UpdateAllCreatures(deltaTime);
   data_->ReproduceCreatures();
-  data_->GenerateMoreFood();
+  data_->GenerateMoreFood(deltaTime);
   data_->UpdateGrid();
   data_->CheckCollisions();
   data_->world_time_ += deltaTime;

--- a/Engine/src/simulationdata.cpp
+++ b/Engine/src/simulationdata.cpp
@@ -117,22 +117,27 @@ void SimulationData::UpdateAllCreatures(double deltaTime) {
  * @brief Generates additional food entities based on the environment's food
  * density.
  */
-void SimulationData::GenerateMoreFood() {
-  double size = food_entities_.size();
-  double max_number = environment_.GetFoodDensity() *
-                      settings::environment::kMapHeight *
-                      settings::environment::kMapWidth / 100;
-  if (creatures_.size() > 300) {//temporary fix so that an abnormal number of creatures can't abuse the food generation system
-      return ;
-  }
-  while (size < max_number) {
-    Food new_food = Food();
-    new_food.RandomInitialization(settings::environment::kMapWidth,
-                                  settings::environment::kMapHeight,
-                                  settings::environment::kMaxFoodSize,
-                                  settings::environment::kMinCreatureSize);
-    food_entities_.emplace_back(new_food);
-    size++;
+void SimulationData::GenerateMoreFood(double deltaTime) {
+  double spawn_cell_size = 50.0;
+  for (double x = 0; x < settings::environment::kMapWidth;
+       x += spawn_cell_size) {
+    for (double y = 0; y < settings::environment::kMapHeight;
+         y += spawn_cell_size) {
+      double food_density = environment_.GetFoodDensity(x, y);
+      double food_spawn_probability = food_density * spawn_cell_size * spawn_cell_size *
+                                      settings::environment::kFoodSpawnRate *
+                                      deltaTime;
+
+      double random_number = static_cast<double>(rand()) / RAND_MAX;
+      if (random_number < food_spawn_probability) {
+        double x_pos =
+            x + static_cast<double>(rand()) / RAND_MAX * spawn_cell_size;
+        double y_pos =
+            y + static_cast<double>(rand()) / RAND_MAX * spawn_cell_size;
+        Food food(x_pos, y_pos);
+        food_entities_.push_back(food);
+      }
+    }
   }
 }
 
@@ -221,17 +226,22 @@ void SimulationData::InitializeCreatures() {
  * @brief Initializes food entities randomly on the map.
  */
 void SimulationData::InitializeFood() {
-  double kFoodDensity = environment_.GetFoodDensity();
   food_entities_.clear();
 
-  // Populate the vector with food entities based on the current food density
-  for (double x = 0; x < settings::environment::kMapWidth; x += 10.0) {
-    for (double y = 0; y < settings::environment::kMapHeight; y += 10.0) {
-      if (std::rand() / (RAND_MAX + 1.0) < kFoodDensity) {
-        food_entities_.emplace_back(Food(x, y));
-      }
-    }
+  for (int i = 0; i < 10000; i++) {
+    GenerateMoreFood(1);
   }
+
+  // const double step_size = 10.0;
+  // // Populate the vector with food entities based on the current food density
+  // for (double x = 0; x < settings::environment::kMapWidth; x += step_size) {
+  //   for (double y = 0; y < settings::environment::kMapHeight; y += step_size) {
+  //     double food_density = environment_.GetFoodDensity(x, y);
+  //     if (std::rand() / (RAND_MAX + 1.0) < food_density * step_size * step_size) {
+  //       food_entities_.emplace_back(Food(x, y));
+  //     }
+  //   }
+  // }
 }
 
 /*!

--- a/UI/src/mainwindow.cpp
+++ b/UI/src/mainwindow.cpp
@@ -63,11 +63,20 @@ MainWindow::~MainWindow() {
 void MainWindow::SetEngine(Engine *engine) {
   engine_ = engine;
   ui_->canvas->SetSimulation(engine_->GetSimulation());
+  auto food_density_function = [this](double x, double y) {
+    return x * 2 / settings::environment::kMapWidth * 5e-5;
+  };
+
+  engine_->GetEnvironment().SetFoodDensity(food_density_function); // Update the density
+  engine_->GetSimulation()->GetSimulationData()->InitializeFood();
 }
 
 void MainWindow::ChangeFoodDensity(int value) {
-  food_density = static_cast<double>(value) / 1000.0;     // Convert to density
-  engine_->GetEnvironment().SetFoodDensity(food_density); // Update the density
+  food_density = static_cast<double>(value) / 10000.0;     // Convert to density
+  auto food_density_function = [this](double x, double y) {
+    return x * 2 / settings::environment::kMapWidth * food_density;
+  };
+  engine_->GetEnvironment().SetFoodDensity(food_density_function); // Update the density
   engine_->UpdateEnvironment(); // Apply the updated density
 }
 

--- a/UI/src/mainwindow.ui
+++ b/UI/src/mainwindow.ui
@@ -46,6 +46,9 @@
       <height>22</height>
      </rect>
     </property>
+    <property name="value">
+     <number>5</number>
+    </property>
    </widget>
    <widget class="QPushButton" name="restartButton">
     <property name="geometry">
@@ -94,6 +97,9 @@
       <width>42</width>
       <height>22</height>
      </rect>
+    </property>
+    <property name="value">
+     <number>5</number>
     </property>
    </widget>
    <widget class="QLineEdit" name="lineEdit_2">
@@ -161,7 +167,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
- Instead of keeping the number of food particles constant throughout the simulation, food now spawns each update cycle regardless of the current number of food particles (spawn rate is adjusted in the config). This prevents overpopulation (and subsequent crashing of the simulation)
- The map gets divided into cells, and each cells spawns a random number of food particles, roughly conforming to the underlying food density function