### PR TITLE
Info panel stays while zooming

### DIFF
--- a/UI/include/simulationcanvas/info_panel.h
+++ b/UI/include/simulationcanvas/info_panel.h
@@ -1,6 +1,8 @@
 #ifndef INFO_PANEL_H
 #define INFO_PANEL_H
 
+
+#include <SFML/Graphics.hpp>
 #include "SFML/Graphics/Font.hpp"
 #include "SFML/Graphics/RenderTarget.hpp"
 #include "creature.h"
@@ -16,6 +18,8 @@ public:
   void SetSelectedCreature(Creature* creature);
   void UpdateSelectedFood();
   Creature* GetSelectedCreature() const;
+  void SetUIView(sf::View view);
+  void SetPanelView(sf::View view);
 
   void Show();
   void Hide();
@@ -35,5 +39,8 @@ private:
 
   void DrawPanel(sf::RenderTarget& target);
   void DrawCreatureInfo(sf::RenderTarget& target);
+
+  sf::View ui_view_;
+  sf::View info_panel_view_;
 };
 #endif // INFO_PANEL_H

--- a/UI/include/simulationcanvas/simulationcanvas.h
+++ b/UI/include/simulationcanvas/simulationcanvas.h
@@ -60,5 +60,8 @@ class SimulationCanvas : public QSFMLCanvas {
   InfoPanel info_panel_;
   void SetSelectedFood();
   void DrawMouseCoordinates();
+
+  sf::View ui_view_;
+  sf::View info_panel_view_;
 };
 

--- a/UI/src/simulationcanvas/info_panel.cpp
+++ b/UI/src/simulationcanvas/info_panel.cpp
@@ -34,6 +34,10 @@ Creature* InfoPanel::GetSelectedCreature() const {
   return selected_creature_;
 }
 
+void InfoPanel::SetUIView(sf::View view){ ui_view_ = view;}
+
+void InfoPanel::SetPanelView(sf::View view){ info_panel_view_ = view;}
+
 void InfoPanel::Show() {
   is_visible_ = true;
 }
@@ -88,6 +92,8 @@ std::string InfoPanel::FormatCreatureInfo(const Creature& creature) {
 }
 
 void InfoPanel::DrawPanel(sf::RenderTarget& target) {
+  target.setView(info_panel_view_);
+
   // Right info panel setup
   sf::Vector2f panelSize(200, target.getSize().y);  // Width of 200 and full height of the canvas
   sf::Vector2f panelPosition(target.getSize().x - panelSize.x, 0);  // Positioned on the right side
@@ -148,6 +154,17 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
   target.draw(healthBarOutline);
   target.draw(healthBar);
 
+  // Prepare and draw the creature info text inside the panel
+  sf::Text infoText;
+  infoText.setFont(texture_manager_->font_);
+  infoText.setString(creature_info.toStdString());
+  infoText.setCharacterSize(15);
+  infoText.setFillColor(sf::Color::White);
+  infoText.setPosition(panelPosition.x + 10, 10);  // Adjust the Y position as needed
+  target.draw(infoText);
+
+  target.setView(ui_view_);
+
   sf::CircleShape redCircle((*selected_creature_).GetSize()); // Adjust as needed
   redCircle.setOutlineColor(sf::Color::Red);
   redCircle.setOutlineThickness((*selected_creature_).GetSize()/5); // Adjust thickness as needed
@@ -174,17 +191,10 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
     target.draw(blueCircle);
   }
 
-  // Prepare and draw the creature info text inside the panel
-  sf::Text infoText;
-  infoText.setFont(texture_manager_->font_);
-  infoText.setString(creature_info.toStdString());
-  infoText.setCharacterSize(15);
-  infoText.setFillColor(sf::Color::White);
-  infoText.setPosition(panelPosition.x + 10, 10);  // Adjust the Y position as needed
-  target.draw(infoText);
 }
 
 void InfoPanel::DrawVisionCone(sf::RenderTarget& target, const Creature &creature) {
+  target.setView(ui_view_);
 
   double visionRadius = creature.GetVisionRadius();
   double visionAngle = creature.GetVisionAngle();

--- a/UI/src/simulationcanvas/simulationcanvas.cpp
+++ b/UI/src/simulationcanvas/simulationcanvas.cpp
@@ -72,15 +72,20 @@ void SimulationCanvas::OnInit()
   clear(sf::Color(0, 255, 0));
   initialViewCenter = getView().getCenter();
   initialViewSize = getView().getSize();
+  ui_view_ = getView();
+  info_panel_view_ = getView();
 }
 
 void SimulationCanvas::OnUpdate()
 {
+  setView(ui_view_);
   RenderSimulation(simulation_->GetSimulationData());
 
   // Check if a creature is selected
   if (info_panel_.IsVisible() && info_panel_.GetSelectedCreature()) {
         info_panel_.UpdateSelectedFood();
+        info_panel_.SetUIView(ui_view_);
+        info_panel_.SetPanelView(info_panel_view_);
         info_panel_.Draw();
   }else if (info_panel_.IsVisible()) {
     std::cout << "Info panel flag is set, but no creature position is recorded."
@@ -211,8 +216,8 @@ std::vector<std::pair<double, double>> SimulationCanvas::getEntityRenderPosition
     std::vector<std::pair<double, double>> positions;
     auto [entityX, entityY] = entity.GetCoordinates();
     double entitySize = entity.GetSize();
-    sf::Vector2f viewCenter = getView().getCenter();
-    sf::Vector2f viewSize = getView().getSize();
+    sf::Vector2f viewCenter = ui_view_.getCenter();
+    sf::Vector2f viewSize = ui_view_.getSize();
     double mapWidth = GetSimulation()->GetSimulationData()->GetEnvironment().GetMapWidth();
     double mapHeight = GetSimulation()->GetSimulationData()->GetEnvironment().GetMapHeight();
 
@@ -312,13 +317,10 @@ void SimulationCanvas::wheelEvent(QWheelEvent *event) {
 }
 
 void SimulationCanvas::zoom(float factor, sf::Vector2f& zoomPoint) {
-    // Get the current view
-    sf::View view = getView();
-
     // Check for maximum zoom
     if (zoomFactor * factor > 1) {
         zoomFactor = 1;
-        view.setCenter(initialViewCenter);
+        ui_view_.setCenter(initialViewCenter);
     } else {
         zoomFactor *= factor;
 
@@ -333,25 +335,25 @@ void SimulationCanvas::zoom(float factor, sf::Vector2f& zoomPoint) {
 
         // Adjust the new center based on the zoom factor and direction
         float zoomSpeed = 0.1f;
-        sf::Vector2f centerDiff = newCenter - view.getCenter();
+        sf::Vector2f centerDiff = newCenter - ui_view_.getCenter();
         if (factor > 1.0f) {
             // Invert the direction for zooming out
             centerDiff *= -(1.0f + 1.0f / (8*factor));
         }
-        view.setCenter(view.getCenter() + centerDiff * zoomSpeed);
+        ui_view_.setCenter(ui_view_.getCenter() + centerDiff * zoomSpeed);
 
         // After adjusting center, get the new mouse position in world coordinates
         sf::Vector2f mouseWorldPosAfterZoom = mapPixelToCoords(mouseScreenPos);
         // Adjust the center again to ensure it's relative to the mouse position
         sf::Vector2f zoomDiff = mouseWorldPosBeforeZoom - mouseWorldPosAfterZoom;
-        view.setCenter(view.getCenter() + zoomDiff * factor);
+        ui_view_.setCenter(ui_view_.getCenter() + zoomDiff * factor);
     }
 
     // Set the new size of the view
-    view.setSize(initialViewSize.x * zoomFactor, initialViewSize.y * zoomFactor);
+    ui_view_.setSize(initialViewSize.x * zoomFactor, initialViewSize.y * zoomFactor);
 
     // Apply the new view and update
-    setView(view);
+    setView(ui_view_);
     update();
 }
 
@@ -381,14 +383,13 @@ void SimulationCanvas::mouseMoveEvent(QMouseEvent* event) {
         sf::Vector2f averagedDelta = std::accumulate(deltaHistory.begin(), deltaHistory.end(), sf::Vector2f(0, 0));
         averagedDelta /= static_cast<float>(deltaHistory.size());
 
-        sf::View view = getView();
-        view.move(averagedDelta);
+        ui_view_.move(averagedDelta);
         // Get map dimensions
         double mapWidth = simulation_->GetSimulationData()->GetEnvironment().GetMapWidth();
         double mapHeight = simulation_->GetSimulationData()->GetEnvironment().GetMapHeight();
 
         // Get the new center of the view
-        sf::Vector2f newCenter = view.getCenter();
+        sf::Vector2f newCenter = ui_view_.getCenter();
 
         // Wrap around horizontally
         if (newCenter.x < 0) {
@@ -410,8 +411,7 @@ void SimulationCanvas::mouseMoveEvent(QMouseEvent* event) {
             newCenter.y -= mapHeight;
         }
         // Set the wrapped center back to the view
-        view.setCenter(newCenter);
-        setView(view);
+        ui_view_.setCenter(newCenter);
 
         initialClickPosition = currentMousePosition;
     }
@@ -430,7 +430,7 @@ void SimulationCanvas::resizeEvent(QResizeEvent* event) {
     sf::View view = getView();
     view.setSize(newSize.x, newSize.y);
     view.setCenter(newSize.x / 2, newSize.y / 2);
-    setView(view);
+    info_panel_view_ = view;
 }
 
 InfoPanel& SimulationCanvas::GetInfoPanel() {


### PR DESCRIPTION
Pls check on mac

Basically when u click on a creature and then zoom in the info panel stays on the right (created an ui_view_ for rendering UI, and an info_panel_view for rendering the info panel text)