### PR TITLE
Small info panel fixes

### DIFF
--- a/Engine/include/collision_functions.h
+++ b/Engine/include/collision_functions.h
@@ -46,7 +46,7 @@ bool CollisionRectangleRectangle(const double tolerance,
 bool IsGridCellPotentiallyInsideCone(Point grid_point, double grid_cell_size,
                                      Point cone_center, double cone_radius,
                                      OrientedAngle cone_left_boundary,
-                                     OrientedAngle cone_right_boundary);
+                                     OrientedAngle cone_right_boundary, double map_width, double map_heigth);
 
 std::vector<std::pair<int, int>> SupercoverBresenhamLine(int x0, int y0, int x1, int y1);
 #endif  // COLLISION_FUNCTIONS_H

--- a/Engine/include/creature.h
+++ b/Engine/include/creature.h
@@ -72,9 +72,8 @@ class Creature : virtual public MovableEntity,
 
 
 
-  std::shared_ptr<Creature> GetClosestEnemyInSight(
-      std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-      double grid_cell_size);
+  std::shared_ptr<Creature> GetClosestEnemyInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
+      double grid_cell_size, double map_width, double map_heigth);
   void ProcessVisionEnemies(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
                             double grid_cell_size, double width, double height);
 

--- a/Engine/include/creature.h
+++ b/Engine/include/creature.h
@@ -69,6 +69,9 @@ class Creature : virtual public MovableEntity,
   bool Compatible(const std::shared_ptr<Creature> other_creature);
 
   void Grab(std::shared_ptr<Entity>entity);
+  void ProcessVision(
+      std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
+      double GridCellSize, double width, double height);
 
 
 

--- a/Engine/include/entity.h
+++ b/Engine/include/entity.h
@@ -48,7 +48,7 @@ class Entity {
                                  otherEntity->GetCoordinates(),
                                  otherEntity->GetSize());
   }
-  double GetRelativeOrientation(const std::shared_ptr<Entity> otherEntity) const;
+  double GetRelativeOrientation(const std::shared_ptr<Entity> otherEntity, double map_width, double map_heigth) const;
 
   int GetID() const;
 

--- a/Engine/include/geometry_primitives.h
+++ b/Engine/include/geometry_primitives.h
@@ -52,7 +52,7 @@ class Point {
 class OrientedAngle {
  public:
   OrientedAngle(double angle);
-  OrientedAngle(const Point &from, const Point &to);
+  OrientedAngle(const Point &from, const Point &to, double map_width, double map_heigth);
   double GetAngle() const;
   OrientedAngle operator+(const OrientedAngle &other) const;
   OrientedAngle operator-(const OrientedAngle &other) const;

--- a/Engine/include/geometry_primitives.h
+++ b/Engine/include/geometry_primitives.h
@@ -30,7 +30,7 @@ class Point {
   Point(std::pair<double, double> coordinates);
   double GetX() const;
   double GetY() const;
-  double dist(const Point &other) const;
+  double dist(const Point &other, double map_width, double map_heigth) const;
   Point operator-(const Point &other) const;
 
  private:

--- a/Engine/include/settings.h
+++ b/Engine/include/settings.h
@@ -69,7 +69,7 @@ class Settings {
     int min_creature_size = 2;
     double reproduction_threshold = 0.80;
     double reproduction_cooldown = 10;
-    int input_neurons = 15;
+    int input_neurons = 11;
     int output_neurons = 6;
     double max_nutritional_value = 2;
     double default_lifespan = 30;

--- a/Engine/include/vision_system.h
+++ b/Engine/include/vision_system.h
@@ -15,30 +15,23 @@ public:
   double GetVisionRadius() const;
   double GetVisionAngle() const;
 
-  std::shared_ptr<Food> GetClosestFood(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-                       double GridCellSize) const;
-  std::shared_ptr<Food> GetClosestFoodInSight(
-      std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-      double grid_cell_size, Food::type type, double map_width, double map_heigth) const;
+  std::shared_ptr<Entity> GetFoodID() const;
 
-  void ProcessVisionFood(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-                         double grid_cell_size, double width, double height);
-  std::shared_ptr<Food> GetFoodID() const;
-  std::shared_ptr<Food> GetClosestPlantInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-          double grid_cell_size, double map_width, double map_heigth) const;
-  std::shared_ptr<Food> GetClosestMeatInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-          double grid_cell_size, double map_width, double map_heigth) const;
-  bool IsInSight(std::shared_ptr<Entity> entity);
+  bool IsInRightDirection(std::shared_ptr<Entity> entity, double map_width, double map_heigth);
   bool IsInVisionCone(std::shared_ptr<Entity> entity, double map_width, double map_heigth) const;
 
+  std::vector<std::shared_ptr<Entity>> GetClosestEntityInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
+                                              double grid_cell_size, double map_width, double map_heigth) const;
+
 protected:
-  double distance_plant_;       /*!< Distance to the nearest plant source. */
+  double distance_entity_;       /*!< Distance to the nearest plant source. */
   double distance_meat_;        /*!< Distance to the nearest meat source. */
-  double orientation_plant_;   /*!< Orientation relative to the nearest plant
+  double orientation_entity_;   /*!< Orientation relative to the nearest plant
                                  source. */
-  double plant_size_;          /*! Size of the closest plant*/
+  double entity_compatibility_;
+  double entity_size_;          /*! Size of the closest plant*/
   double meat_size_;          /*! Size of the closest meat*/
-  std::shared_ptr<Food> closest_plant_;       /*! Closest plant to show in the UI */
+  std::shared_ptr<Entity> closest_entity_;       /*! Closest plant to show in the UI */
   std::shared_ptr<Food> closest_meat_;      /*! Closest meat to show in the UI */
   double orientation_meat_;   /*!< Orientation relative to the nearest meat
                                 source. */
@@ -46,6 +39,8 @@ protected:
                             other entities. */
   double vision_angle_;  /*!< The angle of vision for the creature, representing
                             the field of view. */
+  int number_entities_to_return_;
+  double entity_color_;
 };
 
 double GetRandomFloat(double min_value, double max_value);

--- a/Engine/include/vision_system.h
+++ b/Engine/include/vision_system.h
@@ -19,16 +19,17 @@ public:
                        double GridCellSize) const;
   std::shared_ptr<Food> GetClosestFoodInSight(
       std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-      double grid_cell_size, Food::type type) const;
+      double grid_cell_size, Food::type type, double map_width, double map_heigth) const;
 
   void ProcessVisionFood(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
                          double grid_cell_size, double width, double height);
   std::shared_ptr<Food> GetFoodID() const;
   std::shared_ptr<Food> GetClosestPlantInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-          double grid_cell_size) const;
+          double grid_cell_size, double map_width, double map_heigth) const;
   std::shared_ptr<Food> GetClosestMeatInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-          double grid_cell_size) const;
+          double grid_cell_size, double map_width, double map_heigth) const;
   bool IsInSight(std::shared_ptr<Entity> entity);
+  bool IsInVisionCone(std::shared_ptr<Entity> entity, double map_width, double map_heigth) const;
 
 protected:
   double distance_plant_;       /*!< Distance to the nearest plant source. */

--- a/Engine/src/collision_functions.cpp
+++ b/Engine/src/collision_functions.cpp
@@ -169,9 +169,11 @@ bool CollisionCircleLine(const double& tolerance,
 bool IsGridCellPotentiallyInsideCone(Point grid_point, double grid_cell_size,
                                      Point cone_center, double cone_radius,
                                      OrientedAngle cone_left_boundary,
-                                     OrientedAngle cone_right_boundary) {
+                                     OrientedAngle cone_right_boundary,
+                                     double map_width,
+                                     double map_heigth) {
   auto EPS = SETTINGS.engine.eps;
-  double distance = grid_point.dist(cone_center);
+  double distance = grid_point.dist(cone_center, map_width, map_heigth);
   if (distance < EPS) {
     return true;
   }

--- a/Engine/src/collision_functions.cpp
+++ b/Engine/src/collision_functions.cpp
@@ -182,7 +182,7 @@ bool IsGridCellPotentiallyInsideCone(Point grid_point, double grid_cell_size,
                      SETTINGS.environment.max_food_size + EPS) {
     return false;
   }
-  OrientedAngle cell_relative_angle(cone_center, grid_point);
+  OrientedAngle cell_relative_angle(cone_center, grid_point, map_width, map_heigth);
   double angle_distance = cell_relative_angle.AngleDistanceToCone(
       cone_left_boundary, cone_right_boundary);
   if (sin(angle_distance) >

--- a/Engine/src/creature.cpp
+++ b/Engine/src/creature.cpp
@@ -422,7 +422,7 @@ std::vector<Food *> get_food_at_distance(
  */
 std::shared_ptr<Creature> Creature::GetClosestEnemyInSight(
     std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-    double grid_cell_size){
+    double grid_cell_size, double map_width, double map_heigth){
   int grid_width = grid.size();
   int grid_height = grid[0].size();
 
@@ -461,7 +461,7 @@ std::shared_ptr<Creature> Creature::GetClosestEnemyInSight(
 
         auto direction = OrientedAngle(cone_center, point);
 
-        double distance = point.dist(cone_center);
+        double distance = point.dist(cone_center, map_width, map_heigth);
 
         bool is_in_field_of_view =
             (direction.IsInsideCone(cone_left_boundary, cone_right_boundary));
@@ -506,7 +506,8 @@ std::shared_ptr<Creature> Creature::GetClosestEnemyInSight(
           if (IsGridCellPotentiallyInsideCone(
                   Point(nx * grid_cell_size, ny * grid_cell_size),
                   grid_cell_size, cone_center, vision_radius_,
-                  cone_left_boundary, cone_right_boundary)) {
+                  cone_left_boundary, cone_right_boundary,
+                  map_width, map_heigth)) {
             visited_cells.insert({nx, ny});
             cells_queue.push({nx, ny});
           }
@@ -521,7 +522,7 @@ std::shared_ptr<Creature> Creature::GetClosestEnemyInSight(
 void Creature::ProcessVisionEnemies(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
                        double grid_cell_size, double width, double height)
 {
-  std::shared_ptr<Creature> closeEnemy = GetClosestEnemyInSight(grid, grid_cell_size);
+  std::shared_ptr<Creature> closeEnemy = GetClosestEnemyInSight(grid, grid_cell_size, width, height);
 
   if (closeEnemy){
     distance_enemy_ = this->GetDistance(closeEnemy, width, height) - closeEnemy->GetSize();

--- a/Engine/src/entity.cpp
+++ b/Engine/src/entity.cpp
@@ -182,12 +182,10 @@ double Entity::GetDistance(const std::shared_ptr<Entity> other_entity, const dou
  *
  * @return The relative orientation angle in radians between [-pi,pi].
  */
-double Entity::GetRelativeOrientation(const std::shared_ptr<Entity> other_entity) const {
+double Entity::GetRelativeOrientation(const std::shared_ptr<Entity> other_entity, double map_width, double map_heigth) const {
   // assumes orientation = 0 is the x axis
   return (OrientedAngle(Point(GetCoordinates()),
-                        Point(other_entity->GetCoordinates())) -
-          OrientedAngle(orientation_))
-      .GetAngle();
+                        Point(other_entity->GetCoordinates()), map_width, map_heigth) - OrientedAngle(orientation_)).GetAngle();
 }
 
 /*!

--- a/Engine/src/geometry_primitives.cpp
+++ b/Engine/src/geometry_primitives.cpp
@@ -36,8 +36,11 @@ double Point::GetY() const { return y_; }
  * @param other The other Point to which the distance is calculated.
  * @return The Euclidean distance as a double.
  */
-double Point::dist(const Point &other) const {
-  return hypot(x_ - other.GetX(), y_ - other.GetY());
+double Point::dist(const Point &other, double map_width, double map_heigth) const {
+  const double x_diff = fabs(x_ - other.GetX());
+  const double y_diff = fabs(y_ - other.GetY());
+  return std::hypot(fmin(x_diff, map_width - x_diff),
+                    fmin(y_diff, map_heigth - y_diff));
 }
 
 /*!
@@ -61,8 +64,28 @@ OrientedAngle::OrientedAngle(double angle) : angle_(angle) { Normalize(); }
  * @param from The starting Point.
  * @param to The ending Point.
  */
-OrientedAngle::OrientedAngle(const Point &from, const Point &to)
-    : angle_(atan2(to.GetY() - from.GetY(), to.GetX() - from.GetX())) {
+OrientedAngle::OrientedAngle(const Point &from, const Point &to) {
+
+  auto diff_x = to.GetX() - from.GetX();
+  if (diff_x > SETTINGS.environment.map_width/2)
+  {
+    diff_x -=  SETTINGS.environment.map_width;
+  }
+  if (diff_x < - SETTINGS.environment.map_width/2)
+  {
+    diff_x +=  SETTINGS.environment.map_width;
+  }
+
+  auto diff_y = to.GetY() - from.GetY();
+  if (diff_y > SETTINGS.environment.map_height/2)
+  {
+    diff_y -=  SETTINGS.environment.map_height;
+  }
+  if (diff_y < - SETTINGS.environment.map_height/2)
+  {
+    diff_y +=  SETTINGS.environment.map_height;
+  }
+  angle_ = atan2(diff_y, diff_x);
   Normalize();
 }
 

--- a/Engine/src/geometry_primitives.cpp
+++ b/Engine/src/geometry_primitives.cpp
@@ -64,26 +64,26 @@ OrientedAngle::OrientedAngle(double angle) : angle_(angle) { Normalize(); }
  * @param from The starting Point.
  * @param to The ending Point.
  */
-OrientedAngle::OrientedAngle(const Point &from, const Point &to) {
+OrientedAngle::OrientedAngle(const Point &from, const Point &to, double map_width, double map_heigth) {
 
   auto diff_x = to.GetX() - from.GetX();
-  if (diff_x > SETTINGS.environment.map_width/2)
+  if (diff_x > map_width/2)
   {
-    diff_x -=  SETTINGS.environment.map_width;
+    diff_x -=  map_width;
   }
-  if (diff_x < - SETTINGS.environment.map_width/2)
+  if (diff_x < - map_width/2)
   {
-    diff_x +=  SETTINGS.environment.map_width;
+    diff_x +=  map_width;
   }
 
   auto diff_y = to.GetY() - from.GetY();
-  if (diff_y > SETTINGS.environment.map_height/2)
+  if (diff_y > map_heigth/2)
   {
-    diff_y -=  SETTINGS.environment.map_height;
+    diff_y -=  map_heigth;
   }
-  if (diff_y < - SETTINGS.environment.map_height/2)
+  if (diff_y < - map_heigth/2)
   {
-    diff_y +=  SETTINGS.environment.map_height;
+    diff_y +=  map_heigth;
   }
   angle_ = atan2(diff_y, diff_x);
   Normalize();

--- a/Engine/src/vision_system.cpp
+++ b/Engine/src/vision_system.cpp
@@ -9,7 +9,7 @@ VisionSystem::VisionSystem(neat::Genome genome, Mutable mutables)
       vision_angle_(SETTINGS.physical_constraints.vision_ar_ratio
                     / mutables.GetVisionFactor())
 {
-
+  number_entities_to_return_ = 1;
 }
 
 /*!
@@ -34,113 +34,73 @@ double VisionSystem::GetVisionRadius() const { return vision_radius_; }
 double VisionSystem::GetVisionAngle() const { return vision_angle_; }
 
 
+std::vector<std::shared_ptr<Entity>> VisionSystem::GetClosestEntityInSight(std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
+                                              double grid_cell_size, double map_width, double map_heigth) const
+{
+    int grid_width = grid.size();
+    int grid_height = grid[0].size();
 
-std::shared_ptr<Food> VisionSystem::GetClosestMeatInSight(
-    std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-    double grid_cell_size, double map_width, double map_heigth) const {
-    return (GetClosestFoodInSight(grid, grid_cell_size, Food::type::meat, map_width, map_heigth));
-}
+    int x_grid = static_cast<int>(x_coord_ / grid_cell_size);
+    int y_grid = static_cast<int>(y_coord_ / grid_cell_size);
 
-// Function to get the closest plant in sight
-std::shared_ptr<Food> VisionSystem::GetClosestPlantInSight(
-    std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-    double grid_cell_size, double map_width, double map_heigth) const {
-    return (GetClosestFoodInSight(grid, grid_cell_size, Food::type::plant, map_width, map_heigth));
-}
+    int max_cells_to_find_food = M_PI * pow(vision_radius_ + 2 * sqrt(2) * grid_cell_size + SETTINGS.environment.max_food_size, 2) / (grid_cell_size * grid_cell_size);
 
-/*!
- * @brief Finds the closest food entity (meat or plant) within the VisionSystem's line of sight.
- *
- * @details Performs a breadth-first search (BFS) on the grid cells within the VisionSystem's
- * field of view to locate the closest food entity. It utilizes IsGridCellPotentiallyInsideCone
- * functions to efficiently narrow down the search area to relevant cells. The function iterates over
- * entities within these cells, dynamically casting them to Food* to check if they are edible.
- * It then determines if they are within the VisionSystem's field of view and closer than any previously found food.
- * The search continues until the closest food is found or a predefined number of cells have been processed.
- *
- * @param grid A 3-dimensional vector representing the environmental grid where each cell contains entities.
- * @param grid_cell_size The size of each square cell in the grid.
- *
- * @return A pointer to the closest food entity within the line of sight; nullptr if no food is found.
- */
-std::shared_ptr<Food> VisionSystem::GetClosestFoodInSight(
-    std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-    double grid_cell_size, Food::type food_type, double map_width, double map_heigth) const {
-  int grid_width = grid.size();
-  int grid_height = grid[0].size();
+    auto cone_center = Point(x_coord_, y_coord_);
+    auto cone_orientation = GetOrientation();
+    auto cone_left_boundary = OrientedAngle(cone_orientation - vision_angle_ / 2);
+    auto cone_right_boundary = OrientedAngle(cone_orientation + vision_angle_ / 2);
 
-  int x_grid = static_cast<int>(x_coord_ / grid_cell_size);
-  int y_grid = static_cast<int>(y_coord_ / grid_cell_size);
+    std::vector<std::shared_ptr<Entity>> found_entities;
+    found_entities.reserve(number_entities_to_return_);
 
-  //temporary fix multiply by 4
-  int max_cells_to_find_food = M_PI * pow(vision_radius_ + 2 * sqrt(2) * grid_cell_size + SETTINGS.environment.max_food_size, 2) / (grid_cell_size * grid_cell_size);
+    std::queue<std::pair<int, int>> cells_queue;
+    std::set<std::pair<int, int>> visited_cells;
 
-  auto cone_center = Point(x_coord_, y_coord_);
-  auto cone_orientation = GetOrientation();
-  auto cone_left_boundary = OrientedAngle(cone_orientation - vision_angle_ / 2);
-  auto cone_right_boundary =
-      OrientedAngle(cone_orientation + vision_angle_ / 2);
+    cells_queue.push({x_grid, y_grid});
+    visited_cells.insert({x_grid, y_grid});
 
-  std::shared_ptr<Food> closest_food = nullptr;
-  double smallest_distance_food = std::numeric_limits<double>::max();
+    size_t processed_cells = 0;
 
-  std::queue<std::pair<int, int>> cells_queue;
-  std::set<std::pair<int, int>> visited_cells;
+    while (!cells_queue.empty()) {
+      auto [x, y] = cells_queue.front();
+      cells_queue.pop();
+      ++processed_cells;
 
-  cells_queue.push({x_grid, y_grid});
-  visited_cells.insert({x_grid, y_grid});
-
-  size_t processed_cells = 0;
-
-  while (!cells_queue.empty()) {
-    auto [x, y] = cells_queue.front();
-    cells_queue.pop();
-    ++processed_cells;
-
-    for (auto entity : grid[x][y]) {
-      std::shared_ptr<Food> food = std::dynamic_pointer_cast<Food>(entity);
-
-      if (food && food->GetType()==food_type) {
-        if (IsInVisionCone(food, map_width, map_heigth))
-        {
-          smallest_distance_food = GetDistance(food, map_width, map_heigth);
-          closest_food = food;
-          break;
+      for (auto entity : grid[x][y]) {
+        if (entity &&  entity.get() != this && IsInVisionCone(entity, map_width, map_heigth)) {
+            found_entities.push_back(entity);
+            if (found_entities.size() == number_entities_to_return_) {
+              break;
+            }
         }
       }
-    }
-    if (closest_food) {
-      break;
-    }
-
-    //assert(processed_cells <= max_cells_to_find_food && "processed_cells exceeded max_cells_to_find_food in GetClosestFoodInSight");
-    if (processed_cells > max_cells_to_find_food){
+      if (found_entities.size() == number_entities_to_return_ || processed_cells > max_cells_to_find_food) {
         break;
-    }
+      }
 
-    for (int dx = -1; dx <= 1; ++dx) {
-      for (int dy = -1; dy <= 1; ++dy) {
-        if (dx * dx + dy * dy != 1) continue;
-        int nx = x + dx, ny = y + dy;
-        if (0 <= nx && nx < grid_width && 0 <= ny && ny < grid_height &&
-            !visited_cells.count({nx, ny})) {
-          if (IsGridCellPotentiallyInsideCone(
-                  Point(nx * grid_cell_size, ny * grid_cell_size),
-                  grid_cell_size, cone_center, vision_radius_,
-                  cone_left_boundary, cone_right_boundary,
-                  map_width, map_heigth)) {
-            visited_cells.insert({nx, ny});
-            cells_queue.push({nx, ny});
+      for (int dx = -1; dx <= 1; ++dx) {
+        for (int dy = -1; dy <= 1; ++dy) {
+          if (dx * dx + dy * dy != 1) continue;
+          int nx = x + dx, ny = y + dy;
+          if (0 <= nx && nx < grid_width && 0 <= ny && ny < grid_height && !visited_cells.count({nx, ny})) {
+            if (IsGridCellPotentiallyInsideCone(
+                    Point(nx * grid_cell_size, ny * grid_cell_size),
+                    grid_cell_size, cone_center, vision_radius_,
+                    cone_left_boundary, cone_right_boundary,
+                    map_width, map_heigth)) {
+              visited_cells.insert({nx, ny});
+              cells_queue.push({nx, ny});
+            }
           }
         }
       }
     }
-  }
-  return closest_food;
+    found_entities.resize(number_entities_to_return_, nullptr);
+    return found_entities;
 }
 
 
-bool VisionSystem::IsInSight(std::shared_ptr<Entity> entity)
+bool VisionSystem::IsInRightDirection(std::shared_ptr<Entity> entity, double map_width, double map_heigth)
 {
   auto cone_center = Point(x_coord_, y_coord_);
   auto cone_orientation = GetOrientation();
@@ -148,7 +108,7 @@ bool VisionSystem::IsInSight(std::shared_ptr<Entity> entity)
   auto cone_right_boundary =
       OrientedAngle(cone_orientation + vision_angle_ / 2);
   auto entity_point = Point(entity->GetCoordinates());
-  auto entity_direction = OrientedAngle(cone_center, entity_point);
+  auto entity_direction = OrientedAngle(cone_center, entity_point, map_width, map_heigth);
 
   return entity_direction.IsInsideCone(cone_left_boundary, cone_right_boundary);
 }
@@ -162,7 +122,7 @@ bool VisionSystem::IsInVisionCone(std::shared_ptr<Entity> entity, double map_wid
 
   auto entity_point = Point(entity->GetCoordinates());
 
-  auto food_direction = OrientedAngle(cone_center, entity_point);
+  auto food_direction = OrientedAngle(cone_center, entity_point, map_width, map_heigth);
 
   double distance = entity_point.dist(cone_center, map_width, map_heigth);
 
@@ -181,61 +141,21 @@ bool VisionSystem::IsInVisionCone(std::shared_ptr<Entity> entity, double map_wid
         (distance * cos(food_direction.AngleDistanceToCone(cone_left_boundary, cone_right_boundary)) <= vision_radius_ + SETTINGS.engine.eps);
     if (is_within_vision_radius) { return true;}
   }
+
+  return false;
 }
 
-/*!
- * @brief Processes the VisionSystem's vision to locate food.
- *
- * @details Determines the closest food entity based on the VisionSystem's position
- * and updates the VisionSystem's orientation and distance metrics towards the
- * located food. If there is no food in sight, it assumes the distance to food is
- * the vision radius (so far away), and the orientation is something random
- * in its field of view.
- *
- * @param grid The environmental grid.
- * @param GridCellSize Size of each cell in the grid.
- */
-void VisionSystem::ProcessVisionFood(
-    std::vector<std::vector<std::vector<std::shared_ptr<Entity>>>> &grid,
-    double GridCellSize, double width, double height) {
-  std::shared_ptr<Food> closePlant = GetClosestPlantInSight(grid, GridCellSize, width, height);
-  std::shared_ptr<Food> closeMeat = GetClosestMeatInSight(grid, GridCellSize, width, height);
 
-  if (closePlant){
-        distance_plant_ = this->GetDistance(closePlant, width, height) - closePlant->GetSize();
-        orientation_plant_ = this->GetRelativeOrientation(closePlant);
-        closest_plant_ = closePlant;
-        plant_size_ = closePlant->GetSize();
-  }
-  else {
-      distance_plant_ = vision_radius_;
-      orientation_plant_ = remainder(GetRandomFloat(orientation_- vision_angle_/2, orientation_+ vision_angle_/2), 2*M_PI);
-      closest_plant_ = nullptr;
-      plant_size_ = -1;
-  }
 
-  if (closeMeat){
-        distance_meat_ = this->GetDistance(closeMeat, width, height) - closeMeat->GetSize();
-        orientation_meat_ = this->GetRelativeOrientation(closeMeat);
-        closest_meat_ = closeMeat;
-        meat_size_ = closeMeat->GetSize();
-  }
-  else {
-      distance_meat_ = vision_radius_;
-      orientation_meat_ = remainder(GetRandomFloat(orientation_- vision_angle_/2, orientation_+ vision_angle_/2), 2*M_PI);
-      closest_meat_ = nullptr;
-      meat_size_ = -1;
-  }
-}
+
 
 /*!
  * @brief Retrieves the id of the closest food.
  *
  * @return The id of the closest food or -1 if there is no food in vision.
  */
-std::shared_ptr<Food> VisionSystem::GetFoodID() const {
-  if (distance_plant_ <= distance_meat_) {return closest_plant_;};
-  return closest_meat_;
+std::shared_ptr<Entity> VisionSystem::GetFoodID() const {
+  return closest_entity_;
 }
 
 /*!

--- a/Engine/tests/creature.cpp
+++ b/Engine/tests/creature.cpp
@@ -230,14 +230,14 @@ TEST(CreatureTests, GetClosestFoodInSight_MultipleFoods) {
   creature.SetCoordinates(creature_x, creature_y, 10, 10);
   double target_x = 2.84687, target_y = 2.26958;
   creature.SetOrientation(
-      OrientedAngle(Point(creature_x, creature_y), Point(target_x, target_y))
+      OrientedAngle(Point(creature_x, creature_y), Point(target_x, target_y), 10.0, 10.0)
           .GetAngle());
   creature.SetVision(2.0, M_PI / 3);
 
   auto closest_food =
-      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat, 10.0, 10.0);
+      creature.GetClosestEntityInSight(grid, gridCellSize, 10.0, 10.0);
 
-  ASSERT_EQ(closest_food, meat_1);
+  ASSERT_EQ(closest_food[0], meat_1);
 }
 
 TEST(CreatureTests, GetClosestFoodInSight_NoFoodInSight) {
@@ -265,14 +265,14 @@ TEST(CreatureTests, GetClosestFoodInSight_NoFoodInSight) {
   creature.SetCoordinates(creature_x, creature_y, 10, 10);
   double target_x = 2.84687, target_y = 2.26958;
   creature.SetOrientation(
-      OrientedAngle(Point(creature_x, creature_y), Point(target_x, target_y))
+      OrientedAngle(Point(creature_x, creature_y), Point(target_x, target_y), 10.0, 10.0)
           .GetAngle());
   creature.SetVision(1, M_PI / 3);
 
   auto closest_food =
-      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat, 10.0, 10.0);
+      creature.GetClosestEntityInSight(grid, gridCellSize, 10.0, 10.0);
 
-  ASSERT_EQ(closest_food, nullptr);
+  ASSERT_EQ(closest_food[0], nullptr);
 }
 
 TEST(CreatureTests, Digest) {

--- a/Engine/tests/creature.cpp
+++ b/Engine/tests/creature.cpp
@@ -189,19 +189,19 @@ TEST(CreatureTests, IsGridCellPotentiallyInsideCone) {
 
   auto grid_in_sight_1 = IsGridCellPotentiallyInsideCone(
       Point(5, 5), grid_cell_size, Point(5, 5), 3.0, OrientedAngle(-M_PI / 4),
-      OrientedAngle(M_PI / 4));
+      OrientedAngle(M_PI / 4), 10.0, 10.0);
 
   auto grid_in_sight_2 = IsGridCellPotentiallyInsideCone(
       Point(6, 4), grid_cell_size, Point(5, 5), 3.0, OrientedAngle(-M_PI / 4),
-      OrientedAngle(M_PI / 4));
+      OrientedAngle(M_PI / 4), 10.0, 10.0);
 
   auto grid_in_sight_3 = IsGridCellPotentiallyInsideCone(
       Point(7, 6), grid_cell_size, Point(5, 5), 3.0, OrientedAngle(-M_PI / 4),
-      OrientedAngle(M_PI / 4));
+      OrientedAngle(M_PI / 4), 10.0, 10.0);
 
   auto grid_out_of_sight = IsGridCellPotentiallyInsideCone(
       Point(15, 19), grid_cell_size, Point(1, 1), 3.0, OrientedAngle(-M_PI / 4),
-      OrientedAngle(M_PI / 4));
+      OrientedAngle(M_PI / 4), 10.0, 10.0);
 
   EXPECT_TRUE(grid_in_sight_1);
   EXPECT_TRUE(grid_in_sight_2);
@@ -235,7 +235,7 @@ TEST(CreatureTests, GetClosestFoodInSight_MultipleFoods) {
   creature.SetVision(2.0, M_PI / 3);
 
   auto closest_food =
-      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat);
+      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat, 10.0, 10.0);
 
   ASSERT_EQ(closest_food, meat_1);
 }
@@ -270,7 +270,7 @@ TEST(CreatureTests, GetClosestFoodInSight_NoFoodInSight) {
   creature.SetVision(1, M_PI / 3);
 
   auto closest_food =
-      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat);
+      creature.GetClosestFoodInSight(grid, gridCellSize, Food::type::meat, 10.0, 10.0);
 
   ASSERT_EQ(closest_food, nullptr);
 }

--- a/UI/include/simulationcanvas/info_panel.h
+++ b/UI/include/simulationcanvas/info_panel.h
@@ -33,7 +33,7 @@ private:
   QSFMLCanvas* canvas_;
   Simulation* simulation_;
   std::shared_ptr<Creature> selected_creature_;
-  std::shared_ptr<Food> selected_food_;
+  std::shared_ptr<Entity> closest_entity_;
   bool is_visible_;
   TextureManager* texture_manager_;
 

--- a/UI/include/simulationcanvas/info_panel.h
+++ b/UI/include/simulationcanvas/info_panel.h
@@ -22,7 +22,7 @@ public:
   void Hide();
   bool IsVisible() const;
   void Draw();
-  void DrawVisionCone(sf::RenderTarget& target, const Creature &creature);
+  void DrawVisionCone(sf::RenderTarget& target, const Creature &creature, std::pair<double, double> position);
   void DrawStomach(sf::RenderTarget& target, const Creature& creature);
   std::string FormatCreatureInfo(const Creature& creature);
 

--- a/UI/include/simulationcanvas/info_panel.h
+++ b/UI/include/simulationcanvas/info_panel.h
@@ -28,6 +28,7 @@ public:
 
   void SetUIView(sf::View view);
   void SetPanelView(sf::View view);
+  void SetOffset(float offset_x, float offset_y);
 
 private:
   QSFMLCanvas* canvas_;
@@ -42,5 +43,8 @@ private:
 
   sf::View ui_view_;
   sf::View info_panel_view_;
+
+  float offset_x_;
+  float offset_y_;
 };
 #endif // INFO_PANEL_H

--- a/UI/include/simulationcanvas/simulationcanvas.h
+++ b/UI/include/simulationcanvas/simulationcanvas.h
@@ -34,7 +34,7 @@ class SimulationCanvas : public QSFMLCanvas {
   private:
   Simulation *simulation_ = nullptr;
   virtual void OnInit() override;
-  void OnUpdate();
+  virtual void OnUpdate() override;
 
   // Rendering logic
   void RenderSimulation(SimulationData& data);

--- a/UI/src/mainwindow/mainwindow.cpp
+++ b/UI/src/mainwindow/mainwindow.cpp
@@ -141,9 +141,14 @@ void MainWindow::ToggleSimulation() {
 void MainWindow::RestartSimulation() {
   KillEngine();
   InitializeEngine();
+  // Point graphs and config to new engine
   graph_manager_->SetEngine(engine_);
   config_manager_->SetEngine(engine_);
+  // Start new simulation
+  PauseSimulation();
   RunSimulation();
+  // De-select creature in info panel
+  ui_->canvas->GetInfoPanel().Hide();
 }
 
 

--- a/UI/src/simulationcanvas/info_panel.cpp
+++ b/UI/src/simulationcanvas/info_panel.cpp
@@ -56,7 +56,12 @@ void InfoPanel::Draw() {
   sf::RenderTarget& target = *canvas_;
   DrawStomach(target, *selected_creature_);
   DrawPanel(target);
-  DrawVisionCone(target, *selected_creature_);
+
+  auto creature_position = selected_creature_->GetCoordinates();
+  DrawVisionCone(target, *selected_creature_, creature_position);
+  creature_position.first += offset_x_;
+  creature_position.second += offset_y_;
+  DrawVisionCone(target, *selected_creature_, creature_position);
 }
 
 double round_double(double number, int decimal_places) {
@@ -197,12 +202,15 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
     blueCircle.setPosition(closest_entity_->GetCoordinates().first - closest_entity_->GetSize() + offset_x_,
                            closest_entity_->GetCoordinates().second - closest_entity_->GetSize() + offset_y_);
     target.draw(blueCircle);
+    blueCircle.setPosition(selected_food_->GetCoordinates().first - selected_food_->GetSize(),
+                           selected_food_->GetCoordinates().second - selected_food_->GetSize());
+    target.draw(blueCircle);
   }
 
 
 }
 
-void InfoPanel::DrawVisionCone(sf::RenderTarget& target, const Creature &creature) {
+void InfoPanel::DrawVisionCone(sf::RenderTarget& target, const Creature &creature, std::pair<double, double> position) {
 
   target.setView(ui_view_);
 
@@ -214,18 +222,14 @@ void InfoPanel::DrawVisionCone(sf::RenderTarget& target, const Creature &creatur
   double leftRad = creatureOrientation - visionAngle / 2.0;
   double rightRad = creatureOrientation + visionAngle / 2.0;
 
-  auto [creatureX, creatureY] = creature.GetCoordinates();
-  creatureX += offset_x_;
-  creatureY += offset_y_;
-
   std::vector<sf::Vertex> triangleFan;
-  triangleFan.push_back(sf::Vertex(sf::Vector2f(creatureX, creatureY), sf::Color::Transparent));
+  triangleFan.push_back(sf::Vertex(sf::Vector2f(position.first, position.second), sf::Color::Transparent));
 
   int numPoints = 30;
   for (int i = 0; i <= numPoints; ++i) {
     double angle = leftRad + (i * (rightRad - leftRad) / numPoints);
-    double x = creatureX + visionRadius * cos(angle);
-    double y = creatureY + visionRadius * sin(angle);
+    double x = position.first + visionRadius * cos(angle);
+    double y = position.second + visionRadius * sin(angle);
     triangleFan.push_back(sf::Vertex(sf::Vector2f(x, y), sf::Color(255, 255, 255, 150)));
   }
 

--- a/UI/src/simulationcanvas/info_panel.cpp
+++ b/UI/src/simulationcanvas/info_panel.cpp
@@ -26,13 +26,9 @@ void InfoPanel::SetUIView(sf::View view){ ui_view_ = view;}
 
 void InfoPanel::SetPanelView(sf::View view){ info_panel_view_ = view;}
 
-void InfoPanel::SetSelectedCreature(std::shared_ptr<Creature> creature) {
-  selected_creature_ = creature;
-}
+void InfoPanel::SetSelectedCreature(std::shared_ptr<Creature> creature) {selected_creature_ = creature;}
 
-void InfoPanel::UpdateSelectedFood() {
-  selected_food_ = selected_creature_->GetFoodID();
-}
+void InfoPanel::UpdateSelectedFood() {closest_entity_ = selected_creature_->GetFoodID();}
 
 std::shared_ptr<Creature> InfoPanel::GetSelectedCreature() const {
   return selected_creature_;
@@ -181,13 +177,13 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
     creature_info = QString::fromStdString(FormatCreatureInfo(*selected_creature_));
   }
 
-  if(selected_food_){
-    sf::CircleShape blueCircle(selected_food_->GetSize()); // Adjust as needed
+  if(closest_entity_){
+    sf::CircleShape blueCircle(closest_entity_->GetSize()); // Adjust as needed
     blueCircle.setOutlineColor(sf::Color::Blue);
     blueCircle.setOutlineThickness(2); // Adjust thickness as needed
     blueCircle.setFillColor(sf::Color::Transparent);
-    blueCircle.setPosition(selected_food_->GetCoordinates().first - selected_food_->GetSize(),
-                           selected_food_->GetCoordinates().second - selected_food_->GetSize());
+    blueCircle.setPosition(closest_entity_->GetCoordinates().first - closest_entity_->GetSize(),
+                           closest_entity_->GetCoordinates().second - closest_entity_->GetSize());
     target.draw(blueCircle);
   }
 

--- a/UI/src/simulationcanvas/info_panel.cpp
+++ b/UI/src/simulationcanvas/info_panel.cpp
@@ -26,7 +26,12 @@ void InfoPanel::SetUIView(sf::View view){ ui_view_ = view;}
 
 void InfoPanel::SetPanelView(sf::View view){ info_panel_view_ = view;}
 
-void InfoPanel::SetSelectedCreature(std::shared_ptr<Creature> creature) {selected_creature_ = creature;}
+
+void InfoPanel::SetOffset(float offset_x, float offset_y) {offset_x_ = offset_x; offset_y_ = offset_y; };
+
+void InfoPanel::SetSelectedCreature(std::shared_ptr<Creature> creature) {
+  selected_creature_ = creature;
+}
 
 void InfoPanel::UpdateSelectedFood() {closest_entity_ = selected_creature_->GetFoodID();}
 
@@ -165,6 +170,9 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
   redCircle.setOutlineColor(sf::Color::Red);
   redCircle.setOutlineThickness((*selected_creature_).GetSize()/5); // Adjust thickness as needed
   redCircle.setFillColor(sf::Color::Transparent);
+  redCircle.setPosition((*selected_creature_).GetCoordinates().first - (*selected_creature_).GetSize() + offset_x_,
+                        (*selected_creature_).GetCoordinates().second - (*selected_creature_).GetSize() + offset_y_);
+  target.draw(redCircle);
   redCircle.setPosition((*selected_creature_).GetCoordinates().first - (*selected_creature_).GetSize(),
                         (*selected_creature_).GetCoordinates().second - (*selected_creature_).GetSize());
   target.draw(redCircle);
@@ -182,8 +190,12 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
     blueCircle.setOutlineColor(sf::Color::Blue);
     blueCircle.setOutlineThickness(2); // Adjust thickness as needed
     blueCircle.setFillColor(sf::Color::Transparent);
+
     blueCircle.setPosition(closest_entity_->GetCoordinates().first - closest_entity_->GetSize(),
                            closest_entity_->GetCoordinates().second - closest_entity_->GetSize());
+    target.draw(blueCircle);
+    blueCircle.setPosition(closest_entity_->GetCoordinates().first - closest_entity_->GetSize() + offset_x_,
+                           closest_entity_->GetCoordinates().second - closest_entity_->GetSize() + offset_y_);
     target.draw(blueCircle);
   }
 
@@ -203,6 +215,8 @@ void InfoPanel::DrawVisionCone(sf::RenderTarget& target, const Creature &creatur
   double rightRad = creatureOrientation + visionAngle / 2.0;
 
   auto [creatureX, creatureY] = creature.GetCoordinates();
+  creatureX += offset_x_;
+  creatureY += offset_y_;
 
   std::vector<sf::Vertex> triangleFan;
   triangleFan.push_back(sf::Vertex(sf::Vector2f(creatureX, creatureY), sf::Color::Transparent));

--- a/UI/src/simulationcanvas/info_panel.cpp
+++ b/UI/src/simulationcanvas/info_panel.cpp
@@ -202,9 +202,6 @@ void InfoPanel::DrawPanel(sf::RenderTarget& target) {
     blueCircle.setPosition(closest_entity_->GetCoordinates().first - closest_entity_->GetSize() + offset_x_,
                            closest_entity_->GetCoordinates().second - closest_entity_->GetSize() + offset_y_);
     target.draw(blueCircle);
-    blueCircle.setPosition(selected_food_->GetCoordinates().first - selected_food_->GetSize(),
-                           selected_food_->GetCoordinates().second - selected_food_->GetSize());
-    target.draw(blueCircle);
   }
 
 

--- a/UI/src/simulationcanvas/simulationcanvas.cpp
+++ b/UI/src/simulationcanvas/simulationcanvas.cpp
@@ -339,6 +339,11 @@ void SimulationCanvas::mousePressEvent(QMouseEvent* event) {
 
   // Needed for differentiating clicking and dragging
   initialClickPosition = mousePos;
+
+  sf::Vector2f warpedMousePos;
+  warpedMousePos.x = fmod(mousePos.x + static_cast<float>(SETTINGS.environment.map_width), static_cast<float>(SETTINGS.environment.map_width));
+  warpedMousePos.y = fmod(mousePos.y + static_cast<float>(SETTINGS.environment.map_height), static_cast<float>(SETTINGS.environment.map_height));
+
   isClicking = true;
 
   qDebug() << "Mouse Pressed at: " << mousePos.x << ", " << mousePos.y;
@@ -351,10 +356,11 @@ void SimulationCanvas::mousePressEvent(QMouseEvent* event) {
     float creatureSize = creature->GetSize();
     sf::Vector2f creaturePos(creatureX, creatureY);
 
-    if (sqrt(pow(mousePos.x - creaturePos.x, 2) + pow(mousePos.y - creaturePos.y, 2)) <= creatureSize) {
+    if (sqrt(pow(warpedMousePos.x - creaturePos.x, 2) + pow(warpedMousePos.y - creaturePos.y, 2)) <= creatureSize) {
       qDebug() << "Creature Clicked: ID" << creature->GetID();
       info_panel_.Show();
       info_panel_.SetSelectedCreature(creature);
+      info_panel_.SetOffset(mousePos.x - warpedMousePos.x, mousePos.y - warpedMousePos.y);
       repaint();
       return;
     }


### PR DESCRIPTION
Made info panel work with the warped map, made it dissapear on restart

The only issue is, if a creature selected "outside the map" (on warped coordinates), moves inbound, the red circle around it dissapears (i think fixing this is minor and it's not that important)